### PR TITLE
add support for custom figure props

### DIFF
--- a/lib/components/embed.js
+++ b/lib/components/embed.js
@@ -4,13 +4,13 @@ import FigureCaption from './figure-caption';
 const setup = ({embeds}) => ({
   test: ({embedType}) => embeds[embedType],
   render: ({props}) => {
-    const {embedType, caption} = props;
+    const {embedType, caption, figureProps} = props;
     const embed = embeds[embedType] && embeds[embedType](props);
 
     const captionElm = (caption && caption.length > 0)
       ? <FigureCaption items={caption} /> : '';
 
-    return <figure>{embed}{captionElm}</figure>;
+    return <figure {...figureProps}>{embed}{captionElm}</figure>;
   }
 });
 

--- a/test.js
+++ b/test.js
@@ -43,6 +43,37 @@ test('unknown embed', t => {
   t.end();
 });
 
+test('embed with custom figureProps', t => {
+  t.plan(2);
+
+  const Article = setupArticle({
+    embeds: {
+      twitter: tweet => {
+        t.equal(tweet.id, 'twitter-id');
+        return <span id={tweet.id} />;
+      }
+    }
+  });
+  const items = [{
+    type: 'embed',
+    embedType: 'twitter',
+    id: 'twitter-id',
+    figureProps: {
+      foo: 'bar',
+      hello: 'world'
+    }
+  }];
+  const expected = string.render(
+    <article>
+      <figure foo='bar' hello='world'><span id='twitter-id'/></figure>
+    </article>);
+  const actual = string.render(<Article items={items} />);
+
+  t.equal(actual, expected);
+
+  t.end();
+});
+
 test('text elements', t => {
   const Article = setupArticle({ embeds: {} });
 


### PR DESCRIPTION
Support custom figure props, this is needed to be able to use this for fbia - so that data-feedback="fb:likes,fb:comments" can be added (for example).

R = @iefserge
T = minor