### PR TITLE
pass article props

### DIFF
--- a/lib/components/article.js
+++ b/lib/components/article.js
@@ -1,7 +1,7 @@
 import element from 'magic-virtual-element';
 
 const setup = ({blockList}) => ({
-  render: ({props: {items}}) => <article>{blockList(items)}</article>
+  render: ({props: {items, articleProps = {}}}) => <article {...articleProps}>{blockList(items)}</article>
 });
 
 export default setup;

--- a/test.js
+++ b/test.js
@@ -556,3 +556,17 @@ test('customTextFormattings wraps all other formattings', t => {
   t.equal(actual, expected);
   t.end();
 });
+
+test('articleProps', t => {
+  const Article = setupArticle({ embeds: {} });
+
+  const articleProps = {
+    contenteditable: true,
+    class: 'custom-article-class'
+  };
+  const expected = renderString(tree(<article {...articleProps}></article>));
+  const actual = renderString(tree(<Article articleProps={articleProps} items={[]} />));
+
+  t.equal(actual, expected);
+  t.end();
+});


### PR DESCRIPTION
Type: Minor
Review: @kesla @iefserge 

This is needed for https://github.com/micnews/article-json-to-contenteditable, right now we set contenteditable=true on a wrapper container, but doing that makes it possible to remove the article dom element when hitting backspace and there's not content in the article. And this can be avoided by setting contenteditable directly on the article element. 